### PR TITLE
Fix a few issues to dashboard, jq query and curl not being available

### DIFF
--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -41,7 +41,7 @@ These addons are located in the `samples/addons/` folder of the distribution.
 
 1. To enable distributed tracing, we must explicitly define a provider, and enable it in the mesh, as follows:
 
-    ```yaml linenums="1"
+    ```yaml linenums="1" title="trace-config.yaml"
     --8<-- "observability/trace-config.yaml"
     ```
 
@@ -50,6 +50,10 @@ These addons are located in the `samples/addons/` folder of the distribution.
     ```
 
     Then:
+
+    ```yaml linenums="1" title="enable-tracing.yaml"
+    --8<-- "observability/enable-tracing.yaml"
+    ```
 
     ```shell
     kubectl apply -f observability/enable-tracing.yaml
@@ -164,7 +168,7 @@ With Istio, this is done automatically by the Envoy sidecar.
 1. Run the following command:
 
     ```{.shell .language-shell}
-    kubectl exec svc/customers -- curl -s localhost:15020/stats/prometheus \
+    kubectl exec svc/web-frontend -- wget -qO - localhost:15020/stats/prometheus \
       | grep istio_requests
     ```
 

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -76,7 +76,7 @@ The output can be prettified, and filtered (to highlight the list of host names 
 
 ```shell
 kubectl exec -n istio-system deploy/istiod -- \
-  curl -s localhost:15014/debug/registryz | jq .[].hostname
+  curl -s localhost:15014/debug/registryz | jq '.[].hostname'
 ```
 
 Confirm that the `helloworld` service is listed in the output.

--- a/docs/ingress.md
+++ b/docs/ingress.md
@@ -81,7 +81,7 @@ Configuring ingress with Istio is performed in two parts:
 1. Attempt an HTTP request in your browser to the gateway IP address.
 
     ```shell
-    curl -v http://$GATEWAY_IP/
+    curl -sv http://$GATEWAY_IP/ | head
     ```
 
     It should return a 404: not found.


### PR DESCRIPTION
- The enable-tracing.yaml content was missing on the dashboard workshop. Also added titles to the two yamls in that section.
- Quote the jq query that doesn't work in zsh.
- Update one of the requests as the pod no longer has curl available.